### PR TITLE
get rid of ugly boxes around hyperlinks

### DIFF
--- a/MacFonts/deedy-resume.cls
+++ b/MacFonts/deedy-resume.cls
@@ -11,7 +11,7 @@
 % Package Imports
 \usepackage[hmargin=1.25cm, vmargin=0.7cm]{geometry}
 \usepackage[usenames,dvipsnames]{xcolor}
-\usepackage{hyperref}
+\usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 \usepackage[absolute]{textpos}
 \usepackage[UKenglish]{babel}

--- a/OpenFonts/deedy-resume-openfont.cls
+++ b/OpenFonts/deedy-resume-openfont.cls
@@ -10,7 +10,7 @@
 
 % Package Imports
 \usepackage[hmargin=1.25cm, vmargin=0.75cm]{geometry}
-\usepackage{hyperref}
+\usepackage[hidelinks]{hyperref}
 
 % Publications
 \usepackage{cite}


### PR DESCRIPTION
The boxes don't show up in "Preview" on OSX
but can be clearly seen on default readers for
Windows and Linux (Maybe even on Adobe reader
on OSX...). Remove them!