### PR TITLE
added support for clickable images

### DIFF
--- a/MacFonts/deedy_resume.xtx
+++ b/MacFonts/deedy_resume.xtx
@@ -47,11 +47,29 @@
 
 \documentclass[]{deedy-resume}
 \usepackage{fancyhdr}
+\usepackage{wasysym}
+\usepackage{hyperref}
+\usepackage{graphicx}
  
 \pagestyle{fancy}
 \fancyhf{}
  
 \rfoot{Page \thepage \hspace{1pt}}
+
+\ifxetex
+  \usepackage{letltxmacro}
+  \setlength{\XeTeXLinkMargin}{1pt}
+  \LetLtxMacro\SavedIncludeGraphics\includegraphics
+  \def\includegraphics#1#{% #1 catches optional stuff (star/opt. arg.)
+    \IncludeGraphicsAux{#1}%
+  }%
+  \newcommand*{\IncludeGraphicsAux}[2]{%
+    \XeTeXLinkBox{%
+      \SavedIncludeGraphics#1{#2}%
+    }%
+  }%
+\fi
+
 \begin{document}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/OpenFonts/deedy_resume-openfont.xtx
+++ b/OpenFonts/deedy_resume-openfont.xtx
@@ -47,10 +47,27 @@
 
 \documentclass[]{deedy-resume-openfont}
 \usepackage{fancyhdr}
- 
+\usepackage{wasysym}
+\usepackage{hyperref}
+\usepackage{graphicx}
+
 \pagestyle{fancy}
 \fancyhf{}
- 
+
+\ifxetex
+  \usepackage{letltxmacro}
+  \setlength{\XeTeXLinkMargin}{1pt}
+  \LetLtxMacro\SavedIncludeGraphics\includegraphics
+  \def\includegraphics#1#{% #1 catches optional stuff (star/opt. arg.)
+    \IncludeGraphicsAux{#1}%
+  }%
+  \newcommand*{\IncludeGraphicsAux}[2]{%
+    \XeTeXLinkBox{%
+      \SavedIncludeGraphics#1{#2}%
+    }%
+  }%
+\fi
+
 \begin{document}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This should, in theory, allow users to make use of much more complex methods to
format their resumes as it allows users to add hyperlinks to images. An example
use could be replacing LinkedIn and GitHub links with an icon that opens the
URL. This would make the resumes a lot more space-efficient and easier on the
eye as well as allowing relevant links to stand out from other text on the
page.